### PR TITLE
PRST-2505: feat: add bridge UI customization options

### DIFF
--- a/.github/workflows/push-docker-main.yml
+++ b/.github/workflows/push-docker-main.yml
@@ -31,5 +31,5 @@ jobs:
           push: true
           pull: true
           tags: |
-            gatewayfm/zkevm-bridge-ui-generic:1.1.16
+            gatewayfm/zkevm-bridge-ui-generic:1.1.17
             gatewayfm/zkevm-bridge-ui-generic:latest

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -88,6 +88,12 @@ then
   echo "VITE_REPORT_FORM_URL_ENTRY=$REPORT_FORM_URL_ENTRY" >> $ENV_FILENAME
 fi
 
+# BACKGROUND IMAGE
+if [ ! -z "$SHOW_BACKGROUND_IMAGE" ];
+then
+  echo "VITE_SHOW_BACKGROUND_IMAGE=$SHOW_BACKGROUND_IMAGE" >> $ENV_FILENAME
+fi
+
 echo "Generated .env file:"
 echo "$(cat /app/.env)"
 

--- a/src/adapters/env.ts
+++ b/src/adapters/env.ts
@@ -12,6 +12,7 @@ type Env = {
   VITE_ENABLE_FIAT_EXCHANGE_RATES: string;
   VITE_ENABLE_OUTDATED_NETWORK_MODAL?: string;
   VITE_ENABLE_REPORT_FORM: string;
+  VITE_SHOW_BACKGROUND_IMAGE?: string;
   VITE_ETHEREUM_BRIDGE_CONTRACT_ADDRESS: string;
   VITE_ETHEREUM_EXPLORER_URL: string;
   VITE_ETHEREUM_FORCE_UPDATE_GLOBAL_EXIT_ROOT: string;
@@ -196,6 +197,7 @@ const envToDomain = ({
   VITE_REPORT_FORM_PLATFORM_ENTRY,
   VITE_REPORT_FORM_URL,
   VITE_REPORT_FORM_URL_ENTRY,
+  VITE_SHOW_BACKGROUND_IMAGE,
 }: Env): Promise<domain.Env> => {
   const polygonZkEVMNetworkId = z.coerce.number().positive().parse(VITE_POLYGON_ZK_EVM_NETWORK_ID);
   const isOutdatedNetworkModalEnabled = stringBooleanParser.parse(
@@ -213,6 +215,7 @@ const envToDomain = ({
   const chainIconPath = VITE_CHAIN_ICON_URL;
   const frontendType = VITE_FRONTEND_TYPE ?? "new-design";
   const brandComponents = stringBooleanParser.parse(VITE_BRAND_COMPONENTS ?? "false")
+  const showBackgroundImage = stringBooleanParser.parse(VITE_SHOW_BACKGROUND_IMAGE ?? "true")
 
   const outdatedNetworkModal: domain.Env["outdatedNetworkModal"] = isOutdatedNetworkModalEnabled
     ? {
@@ -277,6 +280,7 @@ const envToDomain = ({
         VITE_REPORT_FORM_URL,
         VITE_REPORT_FORM_URL_ENTRY,
       }),
+      showBackgroundImage,
     };
   });
 };
@@ -318,6 +322,7 @@ const envParser = StrictSchema<Env, domain.Env>()(
       VITE_REPORT_FORM_PLATFORM_ENTRY: z.string().optional(),
       VITE_REPORT_FORM_URL: z.string().optional(),
       VITE_REPORT_FORM_URL_ENTRY: z.string().optional(),
+      VITE_SHOW_BACKGROUND_IMAGE: z.string().optional(),
     })
     .transform(envToDomain)
 );

--- a/src/domain/index.ts
+++ b/src/domain/index.ts
@@ -83,6 +83,7 @@ export type Env = {
   bridgeApiUrl: string;
   chains: [EthereumChain, ZkEVMChain];
   faviconPath?: string;
+  showBackgroundImage: boolean;
   fiatExchangeRates:
     | {
         areEnabled: false;

--- a/src/utils/labels.ts
+++ b/src/utils/labels.ts
@@ -1,4 +1,4 @@
-import { Bridge, Chain, Currency, EthereumChainId } from "src/domain";
+import { Bridge, Currency, EthereumChainId } from "src/domain";
 
 export function getBridgeStatus(status: Bridge["status"], from: Bridge["from"]): string {
   switch (status) {
@@ -35,20 +35,6 @@ export function getEthereumNetworkName(chainId: number): string {
     }
     default: {
       return "Ethereum";
-    }
-  }
-}
-
-export function getDeploymentName(chain: Chain): string | undefined {
-  switch (chain.chainId) {
-    case EthereumChainId.MAINNET: {
-      return "Mainnet Beta";
-    }
-    case EthereumChainId.GOERLI: {
-      return "Testnet";
-    }
-    default: {
-      return undefined;
     }
   }
 }

--- a/src/views/core/layout/layout.view.tsx
+++ b/src/views/core/layout/layout.view.tsx
@@ -35,7 +35,7 @@ export const Layout: FC<PropsWithChildren> = ({ children }) => {
       <div
         className={classes.layout}
         style={
-          showNewDesign
+          showNewDesign && env?.showBackgroundImage
             ? { backgroundImage: `url(${bg})` }
             : { backgroundColor: theme.palette.grey.light }
         }

--- a/src/views/login/login.view.redesign.tsx
+++ b/src/views/login/login.view.redesign.tsx
@@ -1,50 +1,29 @@
-import { FC, useEffect, useState } from "react";
+import { FC, useEffect } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 
 import { NetworkBoxRedesign } from "../shared/network-box/network-box.view.redesign";
 import { WalletListRedesign } from "./components/wallet-list/wallet-list.view.redesign";
 import { routerStateParser } from "src/adapters/browser";
-import { getPolicyCheck, setPolicyCheck } from "src/adapters/storage";
 import ArrowDoubleIcon from "src/assets/icons/arrow-double.svg?react";
 import { useEnvContext } from "src/contexts/env.context";
 import { useProvidersContext } from "src/contexts/providers.context";
-import { EthereumChainId, PolicyCheck, WalletName } from "src/domain";
+import { EthereumChainId, WalletName } from "src/domain";
 import { routes } from "src/routes";
-import { getDeploymentName } from "src/utils/labels";
 import { useLoginRedesignStyles } from "src/views/login/login.styles";
-import { ConfirmationModal } from "src/views/shared/confirmation-modal/confirmation-modal.view";
 import { ErrorMessage } from "src/views/shared/error-message/error-message.view";
 import { InfoBanner } from "src/views/shared/info-banner/info-banner.view";
 import { Typography } from "src/views/shared/typography/typography.view";
 
 export const LoginRedesign: FC = () => {
   const classes = useLoginRedesignStyles();
-  const [selectedWallet, setSelectedWallet] = useState<WalletName>();
-  const [showPolicyModal, setShowPolicyModal] = useState(false);
   const navigate = useNavigate();
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   const { state } = useLocation();
   const { connectedProvider, connectProvider } = useProvidersContext();
   const env = useEnvContext();
 
-  const onConnectProvider = () => {
-    setPolicyCheck();
-    if (selectedWallet) {
-      connectProvider(selectedWallet).catch((error) => {
-        console.error(error);
-      });
-      setShowPolicyModal(false);
-    }
-  };
-
-  const onCheckAndConnectProvider = (walletName: WalletName) => {
-    setSelectedWallet(walletName);
-    const checked = getPolicyCheck();
-    if (checked === PolicyCheck.Checked) {
-      void connectProvider(walletName);
-    } else {
-      setShowPolicyModal(true);
-    }
+  const onSelectWallet = (walletName: WalletName) => {
+    void connectProvider(walletName);
   };
 
   useEffect(() => {
@@ -65,8 +44,7 @@ export const LoginRedesign: FC = () => {
 
   const name = env.networkName;
   const ethereumChain = env.chains[0];
-  const deploymentName = getDeploymentName(ethereumChain);
-  const appName = deploymentName !== undefined ? `${deploymentName} Bridge` : "Bridge";
+  const appName = name ? `${name} Bridge` : "Bridge";
 
   return (
     <div className={classes.login}>
@@ -83,7 +61,7 @@ export const LoginRedesign: FC = () => {
           <NetworkBoxRedesign />
         </div>
         <div className={classes.cardWrap}>
-          <WalletListRedesign onSelectWallet={onCheckAndConnectProvider} />
+          <WalletListRedesign onSelectWallet={onSelectWallet} />
           {connectedProvider.status === "failed" && (
             <ErrorMessage error={connectedProvider.error} />
           )}
@@ -92,21 +70,6 @@ export const LoginRedesign: FC = () => {
           <InfoBanner message={`Connect with ${ethereumChain.name} environment`} />
         )}
       </div>
-
-      {showPolicyModal && (
-        <ConfirmationModal
-          message={
-            <Typography type="body1">
-              DISCLAIMER: This version of the Polygon zkEVM will require frequent maintenance and
-              may be restarted if upgrades are needed.
-            </Typography>
-          }
-          onClose={() => setShowPolicyModal(false)}
-          onConfirm={onConnectProvider}
-          showCancelButton={false}
-          title={`Welcome to the Polygon zkEVM ${deploymentName || ""}`}
-        />
-      )}
     </div>
   );
 };

--- a/src/views/login/login.view.tsx
+++ b/src/views/login/login.view.tsx
@@ -1,18 +1,15 @@
-import { FC, useEffect, useState } from "react";
+import { FC, useEffect } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 
 import { routerStateParser } from "src/adapters/browser";
-import { getPolicyCheck, setPolicyCheck } from "src/adapters/storage";
 import Logo from "src/assets/polygon-zkevm-logo.svg?react";
 import { useEnvContext } from "src/contexts/env.context";
 import { useProvidersContext } from "src/contexts/providers.context";
-import { EthereumChainId, PolicyCheck, WalletName } from "src/domain";
+import { EthereumChainId, WalletName } from "src/domain";
 import { routes } from "src/routes";
-import { getDeploymentName } from "src/utils/labels";
 import { WalletList } from "src/views/login/components/wallet-list/wallet-list.view";
 import { useLoginStyles } from "src/views/login/login.styles";
 import { Card } from "src/views/shared/card/card.view";
-import { ConfirmationModal } from "src/views/shared/confirmation-modal/confirmation-modal.view";
 import { ErrorMessage } from "src/views/shared/error-message/error-message.view";
 import { InfoBanner } from "src/views/shared/info-banner/info-banner.view";
 import { NetworkBox } from "src/views/shared/network-box/network-box.view";
@@ -20,29 +17,14 @@ import { Typography } from "src/views/shared/typography/typography.view";
 
 export const Login: FC = () => {
   const classes = useLoginStyles();
-  const [selectedWallet, setSelectedWallet] = useState<WalletName>();
-  const [showPolicyModal, setShowPolicyModal] = useState(false);
   const navigate = useNavigate();
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   const { state } = useLocation();
   const { connectedProvider, connectProvider } = useProvidersContext();
   const env = useEnvContext();
 
-  const onConnectProvider = () => {
-    setPolicyCheck();
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    selectedWallet && connectProvider(selectedWallet);
-    setShowPolicyModal(false);
-  };
-
-  const onCheckAndConnectProvider = (walletName: WalletName) => {
-    setSelectedWallet(walletName);
-    const checked = getPolicyCheck();
-    if (checked === PolicyCheck.Checked) {
-      void connectProvider(walletName);
-    } else {
-      setShowPolicyModal(true);
-    }
+  const onSelectWallet = (walletName: WalletName) => {
+    void connectProvider(walletName);
   };
 
   useEffect(() => {
@@ -62,9 +44,9 @@ export const Login: FC = () => {
   }
 
   const logo = env.logoPath;
+  const name = env.networkName;
   const ethereumChain = env.chains[0];
-  const deploymentName = getDeploymentName(ethereumChain);
-  const appName = deploymentName !== undefined ? `${deploymentName} Bridge` : "Bridge";
+  const appName = name ? `${name} Bridge` : "Bridge";
 
   return (
     <div className={classes.login}>
@@ -85,7 +67,7 @@ export const Login: FC = () => {
               <Typography className={classes.cardHeader} type="h1">
                 Connect a wallet
               </Typography>
-              <WalletList onSelectWallet={onCheckAndConnectProvider} />
+              <WalletList onSelectWallet={onSelectWallet} />
             </>
           </Card>
           {connectedProvider.status === "failed" && (
@@ -93,20 +75,6 @@ export const Login: FC = () => {
           )}
         </div>
       </div>
-      {showPolicyModal && (
-        <ConfirmationModal
-          message={
-            <Typography type="body1">
-              DISCLAIMER: This version of the Polygon zkEVM will require frequent maintenance and
-              may be restarted if upgrades are needed.
-            </Typography>
-          }
-          onClose={() => setShowPolicyModal(false)}
-          onConfirm={onConnectProvider}
-          showCancelButton={false}
-          title={`Welcome to the Polygon zkEVM ${deploymentName || ""}`}
-        />
-      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- Add `SHOW_BACKGROUND_IMAGE` env var to toggle gradient background (default: true)
- Use `VITE_NETWORK_NAME` for app name instead of hardcoded deployment name
- Remove "Beta" text from deployment name
- Remove disclaimer popup on wallet connect

## Customer Customization
For Billions customer, set the following Docker env vars:
```yaml
environment:
  - VITE_NETWORK_NAME=Billions Bridge
  - VITE_THEME_COLOR_GREY_LIGHT=#FFFFFF
  - VITE_THEME_COLOR_PRIMARY_MAIN_REDESIGN=#0046FF
  - VITE_THEME_COLOR_PRIMARY_DARK=#0035CC
  - VITE_THEME_COLOR_PRIMARY_LIGHT=#D5F0FF
  - SHOW_BACKGROUND_IMAGE=false
```

## Test plan
- [ ] Verify default styling works without new env vars
- [ ] Set `SHOW_BACKGROUND_IMAGE=false` and verify solid color background
- [ ] Set `VITE_NETWORK_NAME=Billions Bridge` and verify title changes
- [ ] Verify "Beta" text is removed from app name
- [ ] Verify disclaimer popup no longer appears on wallet connect

🤖 Generated with [Claude Code](https://claude.com/claude-code)