### PR TITLE
PRST-2505 fix: resolve duplicate key and lint warnings breaking build

### DIFF
--- a/src/views/home/components/header/header.styles.ts
+++ b/src/views/home/components/header/header.styles.ts
@@ -79,9 +79,6 @@ export const useHeaderRedesignStyles = createUseStyles((theme: Theme) => ({
   leftBlock: {
     justifyContent: "left",
   },
-  logo: {
-    height: 56,
-  },
   link: {
     "&:hover": {
       boxShadow: `

--- a/src/views/home/components/header/header.view.redesign.tsx
+++ b/src/views/home/components/header/header.view.redesign.tsx
@@ -47,7 +47,7 @@ export const HeaderRedesign: FC = () => {
                 : 62,
         }}
       >
-        {logoPath ? <img className={classes.logo} src={logoPath} alt={networkName} /> : networkName}
+        {logoPath ? <img alt={networkName} className={classes.logo} src={logoPath} /> : networkName}
       </div>
       <div className={`${classes.block} ${classes.rightBlock}`}>
         <NetworkSelectorRedesign />

--- a/src/views/shared/info-banner/info-banner.styles.ts
+++ b/src/views/shared/info-banner/info-banner.styles.ts
@@ -5,8 +5,8 @@ import { Theme } from "src/styles/theme";
 export const useInfoBannerStyles = createUseStyles((theme: Theme) => ({
   infoBanner: {
     background: theme.palette.grey.main,
-    color: theme.palette.primary.main,
     borderRadius: "8px",
+    color: theme.palette.primary.main,
     display: "flex",
     gap: theme.spacing(1),
     maxWidth: theme.maxWidth,


### PR DESCRIPTION
## Summary
- Remove duplicate `logo` key in header redesign styles that caused TS1117 build error
- Fix `sort-keys-fix` lint ordering in info-banner styles
- Fix `react/jsx-sort-props` lint ordering in header view

## Test plan
- [ ] Verify `vite build` completes without errors
- [ ] Verify no lint warnings in the changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)