### PR TITLE
PRST-2505 feat: show logo image on login page when VITE_LOGO_PATH is set

### DIFF
--- a/.github/workflows/push-docker-main.yml
+++ b/.github/workflows/push-docker-main.yml
@@ -31,5 +31,5 @@ jobs:
           push: true
           pull: true
           tags: |
-            gatewayfm/zkevm-bridge-ui-generic:1.1.18
+            gatewayfm/zkevm-bridge-ui-generic:1.1.19
             gatewayfm/zkevm-bridge-ui-generic:latest

--- a/src/views/login/login.styles.ts
+++ b/src/views/login/login.styles.ts
@@ -116,6 +116,9 @@ export const useLoginRedesignStyles = createUseStyles((theme: Theme) => ({
     width: "100%",
   },
 
+  networkLogo: {
+    height: 56,
+  },
   networkName: {
     fontSize: 48,
     [theme.breakpoints.downM]: {

--- a/src/views/login/login.view.redesign.tsx
+++ b/src/views/login/login.view.redesign.tsx
@@ -43,6 +43,7 @@ export const LoginRedesign: FC = () => {
   }
 
   const name = env.networkName;
+  const logoPath = env.logoPath;
   const ethereumChain = env.chains[0];
   const appName = name ? `${name} Bridge` : "Bridge";
 
@@ -53,9 +54,13 @@ export const LoginRedesign: FC = () => {
           <Typography className={classes.appName} type="body1">
             <ArrowDoubleIcon className={classes.appNameIcon} /> {appName}
           </Typography>
-          <Typography className={classes.networkName} type="body1">
-            {name ? name : env.chains[1].name}
-          </Typography>
+          {logoPath ? (
+            <img alt={name} className={classes.networkLogo} src={logoPath} />
+          ) : (
+            <Typography className={classes.networkName} type="body1">
+              {name ? name : env.chains[1].name}
+            </Typography>
+          )}
         </div>
         <div className={classes.networkBoxWrapper}>
           <NetworkBoxRedesign />


### PR DESCRIPTION
## Summary
- Render logo image from `VITE_LOGO_PATH` on the login page instead of the text network name
- Falls back to text name when `VITE_LOGO_PATH` is not set
- Bump docker image version to 1.1.19

## Test plan
- [ ] Set `VITE_LOGO_PATH` and verify the login page shows the logo image instead of "Billions" text
- [ ] Unset `VITE_LOGO_PATH` and verify the login page falls back to the text network name
- [ ] Verify `vite build` completes without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)