### PR TITLE
PRST-3036 fix: handle EIP-1559 gas when maxFeePerGas < maxPriorityFeePerGas

### DIFF
--- a/src/contexts/bridge.context.tsx
+++ b/src/contexts/bridge.context.tsx
@@ -727,10 +727,16 @@ const BridgeProvider: FC<PropsWithChildren> = (props) => {
               })
           : BigNumber.from(300000);
 
-      const { gasPrice, maxFeePerGas } = await from.provider.getFeeData();
+      const { gasPrice, maxFeePerGas, maxPriorityFeePerGas } = await from.provider.getFeeData();
 
-      if (maxFeePerGas) {
-        return { data: { gasLimit, maxFeePerGas }, type: "eip-1559" };
+      if (maxFeePerGas && maxPriorityFeePerGas) {
+        const adjustedMaxFeePerGas = maxFeePerGas.lt(maxPriorityFeePerGas)
+          ? maxPriorityFeePerGas.mul(2)
+          : maxFeePerGas;
+        return {
+          data: { gasLimit, maxFeePerGas: adjustedMaxFeePerGas, maxPriorityFeePerGas },
+          type: "eip-1559",
+        };
       } else {
         const legacyGasPrice = gasPrice || (await from.provider.getGasPrice());
         const gasPriceIncrease = legacyGasPrice

--- a/src/contexts/bridge.context.tsx
+++ b/src/contexts/bridge.context.tsx
@@ -730,9 +730,14 @@ const BridgeProvider: FC<PropsWithChildren> = (props) => {
       const { gasPrice, maxFeePerGas, maxPriorityFeePerGas } = await from.provider.getFeeData();
 
       if (maxFeePerGas && maxPriorityFeePerGas) {
-        const adjustedMaxFeePerGas = maxFeePerGas.lt(maxPriorityFeePerGas)
-          ? maxPriorityFeePerGas.mul(2)
-          : maxFeePerGas;
+        let adjustedMaxFeePerGas = maxFeePerGas;
+        if (maxFeePerGas.lt(maxPriorityFeePerGas)) {
+          const block = await from.provider.getBlock("latest");
+          const baseFee = block.baseFeePerGas;
+          adjustedMaxFeePerGas = baseFee
+            ? baseFee.mul(2).add(maxPriorityFeePerGas)
+            : maxPriorityFeePerGas.mul(2);
+        }
         return {
           data: { gasLimit, maxFeePerGas: adjustedMaxFeePerGas, maxPriorityFeePerGas },
           type: "eip-1559",

--- a/src/contexts/bridge.context.tsx
+++ b/src/contexts/bridge.context.tsx
@@ -14,7 +14,7 @@ import {
   BRIDGE_CALL_GAS_LIMIT_INCREASE_PERCENTAGE,
   BRIDGE_CALL_PERMIT_GAS_LIMIT_INCREASE,
   FIAT_DISPLAY_PRECISION,
-  GAS_PRICE_INCREASE_PERCENTAGE,
+
   PENDING_TX_TIMEOUT,
 } from "src/constants";
 import { useEnvContext } from "src/contexts/env.context";
@@ -727,31 +727,20 @@ const BridgeProvider: FC<PropsWithChildren> = (props) => {
               })
           : BigNumber.from(300000);
 
-      const { gasPrice, maxFeePerGas, maxPriorityFeePerGas } = await from.provider.getFeeData();
+      const { gasPrice, maxFeePerGas } = await from.provider.getFeeData();
 
-      if (maxFeePerGas && maxPriorityFeePerGas) {
-        let adjustedMaxFeePerGas = maxFeePerGas;
-        if (maxFeePerGas.lt(maxPriorityFeePerGas)) {
-          const block = await from.provider.getBlock("latest");
-          const baseFee = block.baseFeePerGas;
-          adjustedMaxFeePerGas = baseFee
-            ? baseFee.mul(2).add(maxPriorityFeePerGas)
-            : maxPriorityFeePerGas.mul(2);
-        }
+      if (maxFeePerGas) {
         return {
-          data: { gasLimit, maxFeePerGas: adjustedMaxFeePerGas, maxPriorityFeePerGas },
+          data: { gasLimit, maxFeePerGas },
           type: "eip-1559",
         };
       } else {
         const legacyGasPrice = gasPrice || (await from.provider.getGasPrice());
-        const gasPriceIncrease = legacyGasPrice
-          .div(BigNumber.from(100))
-          .mul(GAS_PRICE_INCREASE_PERCENTAGE);
 
         return {
           data: {
             gasLimit,
-            gasPrice: legacyGasPrice.add(gasPriceIncrease),
+            gasPrice: legacyGasPrice,
           },
           type: "legacy",
         };
@@ -780,12 +769,12 @@ const BridgeProvider: FC<PropsWithChildren> = (props) => {
 
       const { account, chainId, provider } = connectedProvider.data;
       const contract = Bridge__factory.connect(from.bridgeContractAddress, provider.getSigner());
+      const estimatedGas = gas
+        ? gas
+        : await estimateBridgeGas({ destinationAddress, from, to, token, tokenSpendPermission });
       const overrides: CallOverrides = {
+        gasLimit: estimatedGas.data.gasLimit,
         value: isTokenEther(token, from) ? amount : undefined,
-        ...(gas
-          ? gas.data
-          : (await estimateBridgeGas({ destinationAddress, from, to, token, tokenSpendPermission }))
-              .data),
       };
 
       const executeBridge = async () => {

--- a/src/domain/index.ts
+++ b/src/domain/index.ts
@@ -252,6 +252,7 @@ export type Gas =
       data: {
         gasLimit: BigNumber;
         maxFeePerGas: BigNumber;
+        maxPriorityFeePerGas: BigNumber;
       };
       type: EIP1559GasType;
     }

--- a/src/domain/index.ts
+++ b/src/domain/index.ts
@@ -252,7 +252,6 @@ export type Gas =
       data: {
         gasLimit: BigNumber;
         maxFeePerGas: BigNumber;
-        maxPriorityFeePerGas: BigNumber;
       };
       type: EIP1559GasType;
     }


### PR DESCRIPTION
## Summary

- Fix bridge transactions being rejected on mainnet when L1 base fees are very low
- Delegate gas price calculation to the wallet (MetaMask) instead of computing it ourselves
- Only pass `gasLimit` (with 20% buffer) in transaction overrides — the wallet handles `maxFeePerGas`, `maxPriorityFeePerGas`, and `gasPrice`
- Fee data is still fetched for the UI estimate display

## Context

With Ethereum L1 base fees at ~0.1 gwei, the bridge UI was computing `maxFeePerGas` (~1.68 gwei) lower than `maxPriorityFeePerGas` (2 gwei), causing ethers.js to reject the transaction:

```
maxFeePerGas cannot be less than maxPriorityFeePerGas
(tx type=2 maxFeePerGas=1680635252 maxPriorityFeePerGas=2000000000)
```

Rather than patching the fee calculation, we now let the wallet handle gas pricing entirely — it already has robust logic for this and exposes a fee UI (slow/medium/fast) to the user.

## Test plan

- [ ] Test L1→L2 bridge deposit on mainnet with current low base fees
- [ ] Verify MetaMask shows its gas fee UI and transaction goes through
- [ ] Verify legacy (non-EIP-1559) chains still work
- [ ] Verify estimated fee display in the confirmation screen is reasonable

🤖 Generated with [Claude Code](https://claude.com/claude-code)