### PR TITLE
PRST-3040 feat(ci): bump image tag to 1.1.21

### DIFF
--- a/.github/workflows/push-docker-main.yml
+++ b/.github/workflows/push-docker-main.yml
@@ -31,5 +31,5 @@ jobs:
           push: true
           pull: true
           tags: |
-            gatewayfm/zkevm-bridge-ui-generic:1.1.20
+            gatewayfm/zkevm-bridge-ui-generic:1.1.21
             gatewayfm/zkevm-bridge-ui-generic:latest


### PR DESCRIPTION
## Summary
- Bump Docker image tag from 1.1.20 to 1.1.21 to include RPC optimization changes from #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)