### PR TITLE
PRST-3867: upgrade openssl (zkevm-bridge-ui-generic)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,9 @@ RUN ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm && \
 # Update Alpine packages
 RUN apk update && apk upgrade --no-cache
 
+# PRST-3867: patch openssl libs for CVE-2026-45447 (libssl3/libcrypto3 3.5.6-r0 -> 3.5.7-r0)
+RUN apk add --no-cache --upgrade libssl3 libcrypto3
+
 WORKDIR /app
 
 COPY package.json package-lock.json ./


### PR DESCRIPTION
Resolves the Aikido openssl finding on the `gatewayfm/zkevm-bridge-ui-generic` container (built from this repo).

| Ticket | Pri | Fix |
|---|---|---|
| [PRST-3867](https://linear.app/gateway-fm/issue/PRST-3867) | High | `libssl3`/`libcrypto3` 3.5.6-r0 → 3.5.7-r0 (CVE-2026-45447, PKCS#7/S-MIME use-after-free) |

Scoped `apk add --no-cache --upgrade libssl3 libcrypto3` in the runtime stage (existing blanket `apk upgrade` left as-is; nghttp2 untouched).

**Verified:** `docker build` OK; image reports `libssl3`/`libcrypto3` `3.5.7-r0`. Aikido scan clean (only pre-existing out-of-scope "runs as root").

🤖 Generated with [Claude Code](https://claude.com/claude-code)