### PR TITLE
chore(deps): bump axios to 1.18.0 (Aikido)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@walletconnect/ethereum-provider": "^2.20.0",
-        "axios": "^1.17.0",
+        "axios": "^1.18.0",
         "copy-to-clipboard": "^3.3.3",
         "ethers": "^5.7.2",
         "events": "^3.3.0",
@@ -5670,9 +5670,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.17.0.tgz",
-      "integrity": "sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.0.tgz",
+      "integrity": "sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
@@ -15331,9 +15331,9 @@
       "dev": true
     },
     "axios": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.17.0.tgz",
-      "integrity": "sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.0.tgz",
+      "integrity": "sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==",
       "requires": {
         "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@walletconnect/ethereum-provider": "^2.20.0",
-    "axios": "^1.17.0",
+    "axios": "^1.18.0",
     "copy-to-clipboard": "^3.3.3",
     "ethers": "^5.7.2",
     "events": "^3.3.0",


### PR DESCRIPTION
## Summary
Bumps axios `1.17.0` → `1.18.0` to remediate HIGH Aikido advisory **AIKIDO-2026-291630**.

axios is a direct dependency; updated in both `package.json` (`^1.18.0`) and `package-lock.json`. No code changes required.

## Verification
- `npm install axios@1.18.0 --package-lock-only --ignore-scripts` applied the bump (lockfile not hand-edited).
- No residual `axios-1.17.0` references remain in `package-lock.json`.
- `npm install --package-lock-only --ignore-scripts` exits 0 (lockfile consistent).
- Confirmed `axios-1.18.0.tgz` resolved in the lockfile.

## Compliance
Counted by the Vanta test "High vulnerabilities identified in code repositories are addressed (Aikido Security)" (ISO 27001:2022, SOC 2, GDPR).

Linear: SEC-1334