### PR TITLE
fix(ci): unblock build-and-push (bump tag to 1.1.23, drop immutable :latest)

### DIFF
--- a/.github/workflows/push-docker-main.yml
+++ b/.github/workflows/push-docker-main.yml
@@ -31,5 +31,5 @@ jobs:
           push: true
           pull: true
           tags: |
-            gatewayfm/zkevm-bridge-ui-generic:1.1.22
+            gatewayfm/zkevm-bridge-ui-generic:1.1.23
             gatewayfm/zkevm-bridge-ui-generic:latest

--- a/.github/workflows/push-docker-main.yml
+++ b/.github/workflows/push-docker-main.yml
@@ -32,4 +32,3 @@ jobs:
           pull: true
           tags: |
             gatewayfm/zkevm-bridge-ui-generic:1.1.23
-            gatewayfm/zkevm-bridge-ui-generic:latest


### PR DESCRIPTION
## What
- Bump the published image tag `gatewayfm/zkevm-bridge-ui-generic:1.1.22 → 1.1.23`.
- Stop pushing the `:latest` tag.

## Why
The `build-and-push` workflow fails at the **push** step. Docker Hub has **tag immutability** enabled on this repository, so re-pushing an already-published tag is denied:

```
denied: requested access to the resource is denied - tag 1.1.22 is already
assigned to an image in this repository and cannot be updated due to
immutability settings. To push this image, use a different tag
```

The image builds fine — only the push is blocked. Bumping to a fresh version tag lets the workflow publish again. `:latest` is removed because immutability blocks reusing it the same way; consumers should pin the versioned tag.

## Follow-up
This is a manual per-release tag bump. A `docker/metadata-action` (auto-tag from git SHA / version) would remove this recurring failure — can be done separately.