### PR TITLE
PRST-4200, PRST-4185: pin Node 22.23.2 base image, patch bundled ip-address (zkevm-bridge-ui)

### DIFF
--- a/.github/workflows/push-docker-main.yml
+++ b/.github/workflows/push-docker-main.yml
@@ -31,4 +31,4 @@ jobs:
           push: true
           pull: true
           tags: |
-            gatewayfm/zkevm-bridge-ui-generic:1.1.23
+            gatewayfm/zkevm-bridge-ui-generic:1.1.24

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,15 @@
 # Stage 1: Node.js for building (using official secure image)
-FROM node:22-alpine AS node-base
+# PRST-4200: pin Node.js to 22.23.2 (fixes 3 high / 4 medium nodejs CVEs flagged by Aikido)
+FROM node:22.23.2-alpine AS node-base
+
+# PRST-4185: npm bundles a vulnerable ip-address (<10.3.1, GHSA-mwp4-54f8-5fhr, SSRF via
+# octal/decimal IPv4 parsing mismatch). No npm release ships the fix yet, so replace the
+# bundled copy with the patched version (dependency-free, satisfies socks' ^10.0.1 range).
+RUN cd /tmp && npm pack ip-address@10.3.1 && \
+    rm -rf /usr/local/lib/node_modules/npm/node_modules/ip-address && \
+    mkdir /usr/local/lib/node_modules/npm/node_modules/ip-address && \
+    tar -xzf ip-address-10.3.1.tgz --strip-components=1 -C /usr/local/lib/node_modules/npm/node_modules/ip-address && \
+    rm ip-address-10.3.1.tgz
 
 # Stage 2: Final image with nginx and node
 FROM nginx:alpine


### PR DESCRIPTION
Fixes two Aikido container findings for `gatewayfm/zkevm-bridge-ui-generic`:

- **PRST-4200 — "Small upgrade for nodejs - gatewayfm/zkevm-bridge-ui-generic"** (High)
  Pins the build-stage base image from floating `node:22-alpine` to `node:22.23.2-alpine`, resolving the 10 nodejs vulnerabilities (3 high / 4 medium / 3 low) flagged by Aikido. https://app.aikido.dev/container/392388?sidebarIssue=22966992

- **PRST-4185 — "Minor upgrade for ip-address - gatewayfm/zkevm-bridge-ui-generic"** (High)
  `ip-address` is **not** a dependency of this project — it only enters the image via npm's own bundled `node_modules` (`npm 10.9.8` ships `ip-address@10.1.0`, vulnerable to the SSRF filter bypass GHSA-mwp4-54f8-5fhr / [AIKIDO-2026-496905](https://intel.aikido.dev/cve/AIKIDO-2026-496905); patched in **10.3.1**). No npm release bundles the fix yet (npm 12.0.2 still ships 10.2.0), so the Dockerfile now swaps npm's bundled copy for `ip-address@10.3.1` in place — it is dependency-free and semver-compatible with npm's `socks@^10.0.1` requirement. https://app.aikido.dev/container/392388?sidebarIssue=37719950

Also bumps the published image tag `1.1.23 → 1.1.24` (Docker Hub tags are immutable per SEC-1507, so a new tag is required for the rebuilt image to publish).

**Verification:** the ip-address swap sequence was executed locally against the real npm tarballs (module loads and functions after replacement, version confirmed 10.3.1). `node:22.23.2-alpine` exists on Docker Hub with amd64+arm64. A local Docker image build was not possible (no Docker daemon available on this machine); CI will build on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
