### PR TITLE
feat(brands): white-label brand support + TEIZA branding and faucet (PRST-4126)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -80,5 +80,14 @@ VITE_THEME_COLOR_WHITE=#ffffff
 VITE_FRONTEND_TYPE=new-design or old-design
 VITE_BRAND_COMPONENTS=true
 
+#BRAND (white-label). Selects the palette / font / logo / header link set at
+#build time from src/brands. Unset or unknown falls back to the default Gateway
+#brand. See docs/branding/teiza.md.
+VITE_BRAND=base
+
+#FAUCET (used only by brands whose faucet is enabled, e.g. teiza)
+VITE_FAUCET_API_URL=
+VITE_FAUCET_SERVING_ADDRESS=
+
 
 

--- a/docs/branding/teiza.md
+++ b/docs/branding/teiza.md
@@ -1,0 +1,93 @@
+# White-label branding & the TEIZA brand
+
+This UI supports multiple client brands from a **single shared codebase and one
+branch**. A brand is selected at **build time** via `VITE_BRAND`, so each client
+ships as its own image built from the same source. Dependency/security bumps land
+once on `develop` and every brand inherits them on the next build — no per-client
+branches or forks to rebase.
+
+Branding is **orthogonal** to `VITE_FRONTEND_TYPE` (`old-design` / `new-design`),
+which still selects the layout generation. A brand skins whichever layout is
+active; `old-design` and `new-design` behave exactly as before.
+
+## Architecture
+
+```
+src/brands/
+  brand.ts        # Brand type
+  index.ts        # registry + `brand` resolved from import.meta.env.VITE_BRAND
+  base.ts         # default Gateway brand (reproduces the previous hard-coded values)
+  teiza.ts        # TEIZA brand
+  teiza/assets/   # TEIZA SVGs (logo, logo-mark, network-mark)
+```
+
+A `Brand` bundles: `palette`, `fontFamily` + `fontFaces`, logo `assets`, the
+marketing `header` (links + deploy button + home/powered-by URLs), and a
+`faucet` config.
+
+Consumption points (all read the build-time `brand`):
+
+- `src/styles/theme.ts` — palette defaults come from `brand.palette`; individual
+  `VITE_THEME_COLOR_*` env vars still override, and `theme.fontFamily` = `brand.fontFamily`.
+- `src/views/app.styles.ts` — `@font-face` set and body font from the brand.
+- `src/views/shared/header-links/header-links.view.redesign.tsx` — logo, links, deploy button.
+- `src/views/core/layout/layout.view.tsx` — "Powered by" footer logo.
+- `src/routes.ts` + `src/views/core/router/router.view.tsx` — the `/faucet` route
+  is only registered when `brand.faucet.enabled`.
+
+**A build with no `VITE_BRAND` is byte-identical to before this change.**
+
+## Onboarding a new client
+
+1. Add `src/brands/<id>.ts` exporting a `Brand` (start from `base`/`teiza`, spread
+   `baseBrand.palette` and override only what differs).
+2. Add its SVG assets under `src/brands/<id>/assets/`.
+3. Register it in `src/brands/index.ts`.
+4. Deploy with `BRAND=<id>` (+ per-deployment content vars below).
+
+Keep as much as possible in **tokens** (palette/font/logo) — those cost nothing at
+security-update time. Only add per-screen component overrides when a design
+restructures layout in a way tokens can't express (TEIZA needed only the new
+faucet screen; everything else is tokens + the existing brand header/footer).
+
+## Deploying TEIZA
+
+`scripts/deploy.sh` maps container env vars → `VITE_*` → build. Set on the
+Deployment/Helm values:
+
+| Container env | Value | Purpose |
+|---|---|---|
+| `BRAND` | `teiza` | selects the TEIZA palette/font/logo/links |
+| `FRONTEND_TYPE` | `new-design` | redesign layout |
+| `BRAND_COMPONENTS` | `true` | show marketing header + "Powered by" footer |
+| `NETWORK_NAME` | `TEIZA Devnet` | title on bridge / faucet / add-network |
+| `NETWORK_SYMBOL` | `TTT` | native symbol |
+| `LOGO_PATH` | URL/path to the circular network mark | network/token icon in headers |
+| `FAVICON_PATH` | TEIZA favicon | browser tab |
+| `FAUCET_API_URL` | faucet POST endpoint | enables the Request button |
+| `FAUCET_SERVING_ADDRESS` | faucet source address | shown in "Serving from" |
+
+Plus the usual chain/bridge/API vars. The faucet route (`/faucet`) is public
+(no wallet required) and appears only for TEIZA.
+
+## ⚠️ Pending client confirmation (needed for pixel-exactness)
+
+The implementation is faithful to the deck but the following are **best-effort
+placeholders** read off the PDF — replace with the client's real values:
+
+1. **Typeface.** `teiza.ts` uses `Poppins` (geometric-sans best match) with the
+   bundled Modern Era faces as a working fallback. Get the real family name +
+   font files from Figma → drop them in `public/fonts/teiza/` and add matching
+   `fontFaces` entries in `teiza.ts` (the `fontFamily` stack already prefers them).
+2. **Exact colours.** Hexes in `teiza.ts` `palette` are eyeballed
+   (primary `#2C48F6`, etc.). Replace with the Figma Dev Mode values.
+3. **Official SVGs.** `src/brands/teiza/assets/*.svg` are hand-recreated
+   (bolt + wordmark + network mark). Replace with the official exports for exact
+   letterforms/geometry.
+4. **Header link URLs + support URL** in `teiza.ts` are `teiza.io/*` placeholders.
+5. **Faucet API contract.** `src/adapters/faucet-api.ts` POSTs `{ address }`;
+   confirm the real request/response shape and success/error semantics.
+
+Also: the deck shows the header title as two-tone ("TEIZA" blue + "Devnet" black).
+Today `NETWORK_NAME` renders as single-colour text; if two-tone is required we can
+either set `LOGO_PATH` to the official lockup image or add a two-tone renderer.

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -94,6 +94,64 @@ then
   echo "VITE_SHOW_BACKGROUND_IMAGE=$SHOW_BACKGROUND_IMAGE" >> $ENV_FILENAME
 fi
 
+# BRANDING (white-label). VITE_BRAND selects the brand token/asset set at build
+# time (src/brands); the rest are per-deployment content. Unset => default brand.
+if [ ! -z "$BRAND" ];
+then
+  echo "VITE_BRAND=$BRAND" >> $ENV_FILENAME
+fi
+
+if [ ! -z "$FRONTEND_TYPE" ];
+then
+  echo "VITE_FRONTEND_TYPE=$FRONTEND_TYPE" >> $ENV_FILENAME
+fi
+
+if [ ! -z "$BRAND_COMPONENTS" ];
+then
+  echo "VITE_BRAND_COMPONENTS=$BRAND_COMPONENTS" >> $ENV_FILENAME
+fi
+
+if [ ! -z "$NETWORK_NAME" ];
+then
+  echo "VITE_NETWORK_NAME=$NETWORK_NAME" >> $ENV_FILENAME
+fi
+
+if [ ! -z "$NETWORK_SYMBOL" ];
+then
+  echo "VITE_NETWORK_SYMBOL=$NETWORK_SYMBOL" >> $ENV_FILENAME
+fi
+
+if [ ! -z "$LOGO_PATH" ];
+then
+  echo "VITE_LOGO_PATH=$LOGO_PATH" >> $ENV_FILENAME
+fi
+
+if [ ! -z "$ICON_PATH" ];
+then
+  echo "VITE_ICON_PATH=$ICON_PATH" >> $ENV_FILENAME
+fi
+
+if [ ! -z "$FAVICON_PATH" ];
+then
+  echo "VITE_FAVICON_PATH=$FAVICON_PATH" >> $ENV_FILENAME
+fi
+
+if [ ! -z "$CHAIN_ICON_URL" ];
+then
+  echo "VITE_CHAIN_ICON_URL=$CHAIN_ICON_URL" >> $ENV_FILENAME
+fi
+
+# FAUCET (only used by brands whose faucet is enabled, e.g. teiza)
+if [ ! -z "$FAUCET_API_URL" ];
+then
+  echo "VITE_FAUCET_API_URL=$FAUCET_API_URL" >> $ENV_FILENAME
+fi
+
+if [ ! -z "$FAUCET_SERVING_ADDRESS" ];
+then
+  echo "VITE_FAUCET_SERVING_ADDRESS=$FAUCET_SERVING_ADDRESS" >> $ENV_FILENAME
+fi
+
 echo "Generated .env file:"
 echo "$(cat /app/.env)"
 

--- a/src/adapters/faucet-api.ts
+++ b/src/adapters/faucet-api.ts
@@ -1,0 +1,11 @@
+import axios from "axios";
+
+// Minimal client for a brand's devnet faucet. The endpoint funds `address` with
+// a fixed amount of the test token. The concrete request/response shape is
+// backend-specific; adjust once the TEIZA faucet API contract is confirmed.
+export const requestFaucetFunds = async (params: {
+  address: string;
+  apiUrl: string;
+}): Promise<void> => {
+  await axios.post(params.apiUrl, { address: params.address });
+};

--- a/src/brands/base.ts
+++ b/src/brands/base.ts
@@ -1,0 +1,84 @@
+import Logo from "src/assets/icons/logo-gatewayfm.svg?react";
+import { Brand } from "src/brands/brand";
+
+// The default Gateway brand. Its palette, font and header links reproduce the
+// values that were previously hard-coded in theme.ts / app.styles.ts /
+// header-links, so a build with no `VITE_BRAND` set is byte-identical to before.
+export const baseBrand: Brand = {
+  assets: {
+    Logo,
+    LogoMark: Logo,
+  },
+  faucet: {
+    apiUrl: "",
+    enabled: false,
+    tokenSymbol: "ETH",
+  },
+  fontFaces: [
+    {
+      fallbacks: [
+        { src: "url('/fonts/modern-era/ModernEra-Regular.woff') format('woff')" },
+        { src: "url('/fonts/modern-era/ModernEra-Regular.ttf') format('truetype')" },
+      ],
+      fontFamily: "Modern Era",
+      fontStyle: "normal",
+      fontWeight: 400,
+      src: "url('/fonts/modern-era/ModernEra-Regular.woff2') format('woff2')",
+    },
+    {
+      fallbacks: [
+        { src: "url('/fonts/modern-era/ModernEra-Medium.woff') format('woff')" },
+        { src: "url('/fonts/modern-era/ModernEra-Medium.ttf') format('truetype')" },
+      ],
+      fontFamily: "Modern Era",
+      fontStyle: "normal",
+      fontWeight: 500,
+      src: "url('/fonts/modern-era/ModernEra-Medium.woff2') format('woff2')",
+    },
+    {
+      fallbacks: [
+        { src: "url('/fonts/modern-era/ModernEra-Bold.woff') format('woff')" },
+        { src: "url('/fonts/modern-era/ModernEra-Bold.ttf') format('truetype')" },
+      ],
+      fontFamily: "Modern Era",
+      fontStyle: "normal",
+      fontWeight: 700,
+      src: "url('/fonts/modern-era/ModernEra-Bold.woff2') format('woff2')",
+    },
+    {
+      fallbacks: [
+        { src: "url('/fonts/modern-era/ModernEra-ExtraBold.woff') format('woff')" },
+        { src: "url('/fonts/modern-era/ModernEra-ExtraBold.ttf') format('truetype')" },
+      ],
+      fontFamily: "Modern Era",
+      fontStyle: "normal",
+      fontWeight: 800,
+      src: "url('/fonts/modern-era/ModernEra-ExtraBold.woff2') format('woff2')",
+    },
+  ],
+  fontFamily: "Modern Era",
+  header: {
+    deployButton: { title: "Deploy rollup", url: "https://presto.gateway.fm/onboarding" },
+    homeUrl: "https://gateway.fm/",
+    links: [
+      { title: "Rollup", url: "https://gateway.fm/presto" },
+      { title: "Stakeway", url: "https://stakeway.com/" },
+      { title: "RPC", url: "https://gateway.fm/rpc" },
+      { title: "Blog", url: "https://gateway.fm/blog" },
+      { title: "About", url: "https://gateway.fm/about" },
+      { title: "Careers", url: "https://boards.eu.greenhouse.io/gatewayfm" },
+    ],
+    poweredByUrl: "https://gateway.fm/",
+  },
+  id: "base",
+  palette: {
+    black: "#0a0b0d",
+    error: { light: "rgba(232,67,12,0.1)", main: "#e8430d" },
+    grey: { dark: "#78798d", light: "#f0f1f6", main: "#e2e5ee", veryDark: "#363740" },
+    primary: { dark: "#5a1cc3", light: "#EEE8FF", main: "#7b3fe4", mainRedesign: "#8950FA" },
+    success: { light: "rgba(0,255,0,0.1)", main: "#54DC04" },
+    transparency: "rgba(8,17,50,0.5)",
+    warning: { light: "rgba(225,126,38,0.1)", main: "#e17e26" },
+    white: "#ffffff",
+  },
+};

--- a/src/brands/brand.ts
+++ b/src/brands/brand.ts
@@ -1,0 +1,65 @@
+import { FC, SVGProps } from "react";
+
+// A Brand bundles everything that varies between white-label deployments of the
+// bridge UI: the colour palette, the UI font, logo assets, the marketing header
+// links, and optional per-brand features (e.g. the TEIZA faucet). Brands are
+// resolved at BUILD time from the `VITE_BRAND` env var (see ./index.ts), so each
+// client ships as its own Docker image from a single shared source tree.
+//
+// This is orthogonal to `VITE_FRONTEND_TYPE` (old-design / new-design), which
+// selects the layout generation. A brand skins whichever layout is active.
+
+export type BrandFontFace = {
+  fallbacks?: { src: string }[];
+  fontFamily: string;
+  fontStyle: string;
+  fontWeight: number;
+  src: string;
+};
+
+// Mirrors the string fields of `Theme["palette"]`. A brand supplies the DEFAULT
+// values; individual `VITE_THEME_COLOR_*` env vars still override them at build
+// time (see src/styles/theme.ts), preserving the existing override behaviour.
+export type BrandPalette = {
+  black: string;
+  error: { light: string; main: string };
+  grey: { dark: string; light: string; main: string; veryDark: string };
+  primary: { dark: string; light: string; main: string; mainRedesign: string };
+  success: { light: string; main: string };
+  transparency: string;
+  warning: { light: string; main: string };
+  white: string;
+};
+
+export type BrandLink = {
+  title: string;
+  url: string;
+};
+
+export type Brand = {
+  assets: {
+    // Horizontal lockup shown in the header and "Powered by" footer.
+    Logo: FC<SVGProps<SVGSVGElement>>;
+    // Compact square/icon mark.
+    LogoMark: FC<SVGProps<SVGSVGElement>>;
+  };
+  faucet: {
+    // POST endpoint that funds an address; when empty the request button is
+    // disabled and the screen renders in a preview-only state.
+    apiUrl: string;
+    // When enabled, a `/faucet` route is registered (see routes.ts / router).
+    enabled: boolean;
+    supportUrl?: string;
+    tokenSymbol: string;
+  };
+  fontFaces: BrandFontFace[];
+  fontFamily: string;
+  header: {
+    deployButton?: BrandLink;
+    homeUrl: string;
+    links: BrandLink[];
+    poweredByUrl: string;
+  };
+  id: string;
+  palette: BrandPalette;
+};

--- a/src/brands/index.ts
+++ b/src/brands/index.ts
@@ -1,0 +1,19 @@
+import { baseBrand } from "src/brands/base";
+import { Brand } from "src/brands/brand";
+import { teizaBrand } from "src/brands/teiza";
+
+// Registry of all supported brands, keyed by the value of `VITE_BRAND`.
+// Add a client here + a `src/brands/<id>.ts` module to onboard a new white-label.
+const brands: Record<string, Brand> = {
+  base: baseBrand,
+  teiza: teizaBrand,
+};
+
+// The active brand, resolved at BUILD time from `VITE_BRAND`. Unset / unknown
+// values fall back to the default Gateway brand, so existing builds are
+// unaffected. Docker builds pass `--build-arg VITE_BRAND=<id>`.
+const brandId = typeof import.meta.env.VITE_BRAND === "string" ? import.meta.env.VITE_BRAND : "base";
+
+export const brand: Brand = brands[brandId] ?? baseBrand;
+
+export type { Brand } from "src/brands/brand";

--- a/src/brands/teiza.ts
+++ b/src/brands/teiza.ts
@@ -1,0 +1,61 @@
+import { baseBrand } from "src/brands/base";
+import { Brand } from "src/brands/brand";
+import LogoMark from "src/brands/teiza/assets/logo-mark.svg?react";
+import Logo from "src/brands/teiza/assets/logo.svg?react";
+
+// TEIZA white-label brand.
+//
+// NOTE (client confirmation pending — see docs/branding/teiza.md):
+//  - Colour hexes below are read off the client PDF and should be replaced with
+//    the exact Figma Dev Mode values.
+//  - The typeface is a geometric-sans best match (Poppins) with the bundled
+//    Modern Era faces kept as a working fallback. When the client supplies the
+//    real TEIZA font files, drop them in /public/fonts/teiza/ and add matching
+//    entries to `fontFaces`; the `fontFamily` stack already prefers them.
+//  - Header link URLs and support URL are placeholders pending real destinations.
+export const teizaBrand: Brand = {
+  assets: {
+    Logo,
+    LogoMark,
+  },
+  faucet: {
+    apiUrl: "",
+    enabled: true,
+    supportUrl: "https://teiza.io/support",
+    tokenSymbol: "TTT",
+  },
+  // Keep the bundled Modern Era faces so text always renders in a real webfont
+  // until the official TEIZA typeface is added.
+  fontFaces: baseBrand.fontFaces,
+  fontFamily: "Poppins, 'Modern Era', system-ui, sans-serif",
+  header: {
+    deployButton: { title: "Deploy rollup", url: "https://teiza.io/deploy" },
+    homeUrl: "https://teiza.io/",
+    links: [
+      { title: "Rollup", url: "https://teiza.io/rollup" },
+      { title: "Stakeway", url: "https://stakeway.com/" },
+      { title: "RPC", url: "https://teiza.io/rpc" },
+      { title: "Blog", url: "https://teiza.io/blog" },
+      { title: "About", url: "https://teiza.io/about" },
+      { title: "Careers", url: "https://teiza.io/careers" },
+    ],
+    poweredByUrl: "https://teiza.io/",
+  },
+  id: "teiza",
+  palette: {
+    ...baseBrand.palette,
+    grey: {
+      dark: "#6B7280",
+      light: "#F4F6FF",
+      main: "#E6E9F5",
+      veryDark: "#1B1C22",
+    },
+    primary: {
+      dark: "#1E34C9",
+      light: "#EDEFFD",
+      main: "#2C48F6",
+      mainRedesign: "#2C48F6",
+    },
+    transparency: "rgba(16,24,64,0.5)",
+  },
+};

--- a/src/brands/teiza/assets/logo-mark.svg
+++ b/src/brands/teiza/assets/logo-mark.svg
@@ -1,0 +1,6 @@
+<!-- TEIZA app-icon mark: white bolt on a rounded blue square.
+     Recreated from the client deck; replace with the official Figma export. -->
+<svg width="44" height="44" viewBox="0 0 44 44" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="44" height="44" rx="11" fill="#2C48F6"/>
+  <path d="M25 9 L14 24 H21 L19 35 L31 19 H23.4 L25 9 Z" fill="#fff"/>
+</svg>

--- a/src/brands/teiza/assets/logo.svg
+++ b/src/brands/teiza/assets/logo.svg
@@ -1,0 +1,6 @@
+<!-- TEIZA header/footer lockup: blue lightning bolt + dark wordmark.
+     Recreated from the client deck; replace with the official Figma export for exact letterforms. -->
+<svg width="132" height="36" viewBox="0 0 132 36" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M22.5 4 L9 20.5 H16.8 L14 32 L28 14.5 H20.2 L22.5 4 Z" fill="#2C48F6"/>
+  <text x="40" y="25" font-family="Poppins, 'Modern Era', system-ui, sans-serif" font-size="22" font-weight="700" letter-spacing="5" fill="#0A0B0D">TEIZA</text>
+</svg>

--- a/src/brands/teiza/assets/network-mark.svg
+++ b/src/brands/teiza/assets/network-mark.svg
@@ -1,0 +1,7 @@
+<!-- TEIZA network / token mark: angular triangular monogram inside a blue disc.
+     Recreated approximation from the client deck; replace with the official Figma export. -->
+<svg width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="20" cy="20" r="20" fill="#2C48F6"/>
+  <path d="M9 13 H31 L27.5 19 H15.5 L20 27 L23 21.5 L26 21.5 L20 32 Z" fill="#fff"/>
+  <path d="M23.5 19 L26.5 13.5 L31 13.5 L28 19 Z" fill="#fff"/>
+</svg>

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -2,6 +2,7 @@ export type RouteId =
   | "activity"
   | "bridgeConfirmation"
   | "bridgeDetails"
+  | "faucet"
   | "home"
   | "login"
   | "networkError"
@@ -30,6 +31,11 @@ export const routes: {
     id: "bridgeDetails",
     isPrivate: true,
     path: "/bridge-details/:bridgeId",
+  },
+  faucet: {
+    id: "faucet",
+    isPrivate: false,
+    path: "/faucet",
   },
   home: {
     id: "home",

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -1,3 +1,5 @@
+import { brand } from "src/brands";
+
 export const getEnv = (key: keyof ImportMetaEnv, defaultValue: string): string  => {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   const value = import.meta.env[key];
@@ -10,6 +12,7 @@ export type Theme = {
     downM: string;
     upSm: string;
   };
+  fontFamily: string;
   hoverTransition: string;
   maxWidth: number;
   palette: {
@@ -44,42 +47,48 @@ export type Theme = {
   spacing: (value: number) => number;
 };
 
+// Palette defaults come from the active brand (src/brands). Individual
+// `VITE_THEME_COLOR_*` env vars still override them, preserving prior behaviour.
 export const theme: Theme = {
   breakpoints: {
     downLg: "@media (max-width: 1024px)",
     downM: "@media (max-width: 788px)",
     upSm: "@media (min-width: 480px)",
   },
+  fontFamily: brand.fontFamily,
   hoverTransition: "all 150ms",
   maxWidth: 644,
   palette: {
-    black: getEnv("VITE_THEME_COLOR_BLACK", "#0a0b0d"),
+    black: getEnv("VITE_THEME_COLOR_BLACK", brand.palette.black),
     error: {
-      light: getEnv("VITE_THEME_COLOR_ERROR_LIGHT", "rgba(232,67,12,0.1)"),
-      main: getEnv("VITE_THEME_COLOR_ERROR_MAIN", "#e8430d"),
+      light: getEnv("VITE_THEME_COLOR_ERROR_LIGHT", brand.palette.error.light),
+      main: getEnv("VITE_THEME_COLOR_ERROR_MAIN", brand.palette.error.main),
     },
     grey: {
-      dark: getEnv("VITE_THEME_COLOR_GREY_DARK", "#78798d"),
-      light: getEnv("VITE_THEME_COLOR_GREY_LIGHT", "#f0f1f6"),
-      main: getEnv("VITE_THEME_COLOR_GREY_MAIN", "#e2e5ee"),
-      veryDark: getEnv("VITE_THEME_COLOR_GREY_VERY_DARK", "#363740"),
+      dark: getEnv("VITE_THEME_COLOR_GREY_DARK", brand.palette.grey.dark),
+      light: getEnv("VITE_THEME_COLOR_GREY_LIGHT", brand.palette.grey.light),
+      main: getEnv("VITE_THEME_COLOR_GREY_MAIN", brand.palette.grey.main),
+      veryDark: getEnv("VITE_THEME_COLOR_GREY_VERY_DARK", brand.palette.grey.veryDark),
     },
     primary: {
-      dark: getEnv("VITE_THEME_COLOR_PRIMARY_DARK", "#5a1cc3"),
-      light: getEnv("VITE_THEME_COLOR_PRIMARY_LIGHT", "#EEE8FF"),
-      main: getEnv("VITE_THEME_COLOR_PRIMARY_MAIN", "#7b3fe4"),
-      mainRedesign: getEnv("VITE_THEME_COLOR_PRIMARY_MAIN_REDESIGN", "#8950FA"),
+      dark: getEnv("VITE_THEME_COLOR_PRIMARY_DARK", brand.palette.primary.dark),
+      light: getEnv("VITE_THEME_COLOR_PRIMARY_LIGHT", brand.palette.primary.light),
+      main: getEnv("VITE_THEME_COLOR_PRIMARY_MAIN", brand.palette.primary.main),
+      mainRedesign: getEnv(
+        "VITE_THEME_COLOR_PRIMARY_MAIN_REDESIGN",
+        brand.palette.primary.mainRedesign
+      ),
     },
     success: {
-      light: getEnv("VITE_THEME_COLOR_SUCCESS_LIGHT", "rgba(0,255,0,0.1)"),
-      main: getEnv("VITE_THEME_COLOR_SUCCESS_MAIN", "#54DC04"),
+      light: getEnv("VITE_THEME_COLOR_SUCCESS_LIGHT", brand.palette.success.light),
+      main: getEnv("VITE_THEME_COLOR_SUCCESS_MAIN", brand.palette.success.main),
     },
-    transparency: getEnv("VITE_THEME_COLOR_TRANSPARENCY", "rgba(8,17,50,0.5)"),
+    transparency: getEnv("VITE_THEME_COLOR_TRANSPARENCY", brand.palette.transparency),
     warning: {
-      light: getEnv("VITE_THEME_COLOR_WARNING_LIGHT", "rgba(225,126,38,0.1)"),
-      main: getEnv("VITE_THEME_COLOR_WARNING_MAIN", "#e17e26"),
+      light: getEnv("VITE_THEME_COLOR_WARNING_LIGHT", brand.palette.warning.light),
+      main: getEnv("VITE_THEME_COLOR_WARNING_MAIN", brand.palette.warning.main),
     },
-    white: getEnv("VITE_THEME_COLOR_WHITE", "#ffffff"),
+    white: getEnv("VITE_THEME_COLOR_WHITE", brand.palette.white),
   },
   spacing: (value: number): number => value * 8,
 };

--- a/src/views/app.styles.ts
+++ b/src/views/app.styles.ts
@@ -1,50 +1,11 @@
 import { createUseStyles } from "react-jss";
 
+import { brand } from "src/brands";
 import { Theme } from "src/styles/theme";
 
 export const useAppStyles = createUseStyles((theme: Theme) => ({
-  "@font-face": [
-    {
-      fallbacks: [
-        { src: "url('/fonts/modern-era/ModernEra-Regular.woff') format('woff')" },
-        { src: "url('/fonts/modern-era/ModernEra-Regular.ttf') format('truetype')" },
-      ],
-      fontFamily: "Modern Era",
-      fontStyle: "normal",
-      fontWeight: 400,
-      src: "url('/fonts/modern-era/ModernEra-Regular.woff2') format('woff2')",
-    },
-    {
-      fallbacks: [
-        { src: "url('/fonts/modern-era/ModernEra-Medium.woff') format('woff')" },
-        { src: "url('/fonts/modern-era/ModernEra-Medium.ttf') format('truetype')" },
-      ],
-      fontFamily: "Modern Era",
-      fontStyle: "normal",
-      fontWeight: 500,
-      src: "url('/fonts/modern-era/ModernEra-Medium.woff2') format('woff2')",
-    },
-    {
-      fallbacks: [
-        { src: "url('/fonts/modern-era/ModernEra-Bold.woff') format('woff')" },
-        { src: "url('/fonts/modern-era/ModernEra-Bold.ttf') format('truetype')" },
-      ],
-      fontFamily: "Modern Era",
-      fontStyle: "normal",
-      fontWeight: 700,
-      src: "url('/fonts/modern-era/ModernEra-Bold.woff2') format('woff2')",
-    },
-    {
-      fallbacks: [
-        { src: "url('/fonts/modern-era/ModernEra-ExtraBold.woff') format('woff')" },
-        { src: "url('/fonts/modern-era/ModernEra-ExtraBold.ttf') format('truetype')" },
-      ],
-      fontFamily: "Modern Era",
-      fontStyle: "normal",
-      fontWeight: 800,
-      src: "url('/fonts/modern-era/ModernEra-ExtraBold.woff2') format('woff2')",
-    },
-  ],
+  // Font faces are supplied by the active brand (src/brands).
+  "@font-face": brand.fontFaces,
   "@global": {
     "#app-root": {
       alignItems: "center",
@@ -70,7 +31,7 @@ export const useAppStyles = createUseStyles((theme: Theme) => ({
       color: theme.palette.black,
       display: "flex",
       flexDirection: "column",
-      fontFamily: "Modern Era",
+      fontFamily: theme.fontFamily,
       fontSize: 16,
       margin: 0,
       maxHeight: "100%",

--- a/src/views/core/layout/layout.view.tsx
+++ b/src/views/core/layout/layout.view.tsx
@@ -2,7 +2,7 @@ import { FC, PropsWithChildren, useEffect, useState } from "react";
 const bg = "/gradient-background.png";
 
 import { reportError } from "src/adapters/error";
-import LogoGatewayfm from "src/assets/icons/logo-gatewayfm.svg?react";
+import { brand } from "src/brands";
 import { useEnvContext } from "src/contexts/env.context";
 import { useUIContext } from "src/contexts/ui.context";
 import { theme } from "src/styles/theme";
@@ -45,7 +45,7 @@ export const Layout: FC<PropsWithChildren> = ({ children }) => {
         {showBrandComponents && (
           <div className={classes.poweredLogoBox}>
             Powered by{" "}
-            <LogoGatewayfm onClick={() => window.open("https://gateway.fm/", "_blank")} />
+            <brand.assets.Logo onClick={() => window.open(brand.header.poweredByUrl, "_blank")} />
           </div>
         )}
       </div>

--- a/src/views/core/router/router.view.tsx
+++ b/src/views/core/router/router.view.tsx
@@ -1,6 +1,7 @@
 import { ComponentType, FC, useMemo } from "react";
 import { Navigate, Route, Routes } from "react-router-dom";
 
+import { brand } from "src/brands";
 import { useEnvContext } from "src/contexts/env.context";
 import { RouteId, routes } from "src/routes";
 import { areSettingsVisible } from "src/utils/feature-toggles";
@@ -10,6 +11,7 @@ import { BridgeConfirmation } from "src/views/bridge-confirmation/bridge-confirm
 import { BridgeConfirmationRedesign } from "src/views/bridge-confirmation/bridge-confirmation.view.redesign";
 import { BridgeDetails } from "src/views/bridge-details/bridge-details.view";
 import { BridgeDetailsRedesign } from "src/views/bridge-details/bridge-details.view.redisign";
+import { FaucetRedesign } from "src/views/faucet/faucet.view.redesign";
 import { Home } from "src/views/home/home.view";
 import { HomeRedesign } from "src/views/home/home.view.redesign";
 import { Login } from "src/views/login/login.view";
@@ -22,6 +24,7 @@ const redesignComponents : Record<RouteId, ComponentType> = {
   activity: ActivityRedesign,
   bridgeConfirmation: BridgeConfirmationRedesign,
   bridgeDetails: BridgeDetailsRedesign,
+  faucet: FaucetRedesign,
   home: HomeRedesign,
   login: LoginRedesign,
   networkError: NetworkError,
@@ -31,6 +34,7 @@ const baseComponents: Record<RouteId, ComponentType> = {
   activity: Activity,
   bridgeConfirmation: BridgeConfirmation,
   bridgeDetails: BridgeDetails,
+  faucet: FaucetRedesign,
   home: Home,
   login: Login,
   networkError: NetworkError,
@@ -45,14 +49,19 @@ export const Router: FC = () => {
     [frontendType]
   );
 
-  const filteredRoutes =
-    !env || areSettingsVisible(env)
-      ? routes
-      : Object.values(routes).filter((route) => route.path !== routes.settings.path);
+  const filteredRoutes = Object.values(routes).filter((route) => {
+    if (route.id === "settings" && env && !areSettingsVisible(env)) {
+      return false;
+    }
+    if (route.id === "faucet" && !brand.faucet.enabled) {
+      return false;
+    }
+    return true;
+  });
 
   return (
     <Routes>
-      {Object.values(filteredRoutes).map(({ id, isPrivate, path }) => {
+      {filteredRoutes.map(({ id, isPrivate, path }) => {
         const Component = components[id];
         return (
           <Route

--- a/src/views/faucet/faucet.styles.ts
+++ b/src/views/faucet/faucet.styles.ts
@@ -1,0 +1,162 @@
+import { createUseStyles } from "react-jss";
+
+import { Theme } from "src/styles/theme";
+
+export const useFaucetStyles = createUseStyles((theme: Theme) => ({
+  addressInput: {
+    "&::placeholder": {
+      color: theme.palette.grey.dark,
+    },
+    "&:focus": {
+      borderColor: theme.palette.primary.main,
+      outline: "none",
+    },
+    backgroundColor: theme.palette.white,
+    border: `1px solid ${theme.palette.grey.main}`,
+    borderRadius: 12,
+    color: theme.palette.black,
+    fontFamily: theme.fontFamily,
+    fontSize: 16,
+    padding: [theme.spacing(2), theme.spacing(2.5)],
+    width: "100%",
+  },
+  badge: {
+    alignItems: "center",
+    backgroundColor: theme.palette.primary.light,
+    borderRadius: 40,
+    color: theme.palette.primary.main,
+    display: "inline-flex",
+    fontSize: 15,
+    fontWeight: 600,
+    gap: theme.spacing(1),
+    marginBottom: theme.spacing(3),
+    padding: [theme.spacing(1), theme.spacing(2.5)],
+  },
+  badgeDot: {
+    backgroundColor: theme.palette.primary.main,
+    borderRadius: "50%",
+    height: 8,
+    width: 8,
+  },
+  buttonWrap: {
+    display: "flex",
+    justifyContent: "center",
+    marginTop: theme.spacing(4),
+  },
+  card: {
+    background: theme.palette.white,
+    borderRadius: 24,
+    boxShadow: "0px 4px 8px 4px rgba(0, 0, 0, 0.1)",
+    display: "flex",
+    flexDirection: "column",
+    gap: theme.spacing(3),
+    padding: theme.spacing(4),
+    textAlign: "left",
+    width: "100%",
+  },
+  contentWrapper: {
+    alignItems: "center",
+    display: "flex",
+    flexDirection: "column",
+    margin: "auto",
+    maxWidth: 900,
+    textAlign: "center",
+    width: "100%",
+  },
+  copyButton: {
+    alignItems: "center",
+    background: "transparent",
+    border: "none",
+    cursor: "pointer",
+    display: "flex",
+    padding: theme.spacing(0.5),
+  },
+  copyIcon: {
+    height: 18,
+    width: 18,
+  },
+  faucet: {
+    display: "flex",
+    flexDirection: "column",
+    padding: [theme.spacing(2), theme.spacing(2), theme.spacing(6)],
+    width: "100%",
+  },
+  fieldLabel: {
+    color: theme.palette.black,
+    fontSize: 16,
+    fontWeight: 500,
+    whiteSpace: "nowrap",
+  },
+  heading: {
+    fontSize: 84,
+    fontWeight: 700,
+    lineHeight: 1.05,
+    margin: [theme.spacing(2), 0, theme.spacing(5)],
+    [theme.breakpoints.downLg]: {
+      fontSize: 64,
+    },
+    [theme.breakpoints.downM]: {
+      fontSize: 40,
+    },
+  },
+  headingAccent: {
+    color: theme.palette.primary.main,
+  },
+  helperLink: {
+    color: theme.palette.primary.main,
+    textDecoration: "underline",
+  },
+  helperText: {
+    color: theme.palette.black,
+    fontSize: 15,
+    lineHeight: 1.6,
+    marginTop: theme.spacing(3),
+    textAlign: "center",
+  },
+  mark: {
+    height: 56,
+    marginBottom: theme.spacing(3),
+    width: 56,
+  },
+  requestError: {
+    color: theme.palette.error.main,
+    fontSize: 14,
+    marginTop: theme.spacing(2),
+    textAlign: "center",
+  },
+  requestSuccess: {
+    color: theme.palette.success.main,
+    fontSize: 14,
+    marginTop: theme.spacing(2),
+    textAlign: "center",
+  },
+  servingAddress: {
+    color: theme.palette.black,
+    fontSize: 15,
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
+  },
+  servingRow: {
+    alignItems: "center",
+    display: "flex",
+    gap: theme.spacing(2),
+    [theme.breakpoints.downM]: {
+      alignItems: "flex-start",
+      flexDirection: "column",
+      gap: theme.spacing(1),
+    },
+  },
+  servingValue: {
+    alignItems: "center",
+    backgroundColor: theme.palette.primary.light,
+    borderRadius: 12,
+    display: "flex",
+    flex: 1,
+    gap: theme.spacing(1),
+    justifyContent: "space-between",
+    minWidth: 0,
+    padding: [theme.spacing(1.5), theme.spacing(2)],
+    width: "100%",
+  },
+}));

--- a/src/views/faucet/faucet.view.redesign.tsx
+++ b/src/views/faucet/faucet.view.redesign.tsx
@@ -1,0 +1,154 @@
+import copy from "copy-to-clipboard";
+import { FC, useState } from "react";
+
+import { requestFaucetFunds } from "src/adapters/faucet-api";
+import CopyIcon from "src/assets/icons/copy.svg?react";
+import { brand } from "src/brands";
+import { useEnvContext } from "src/contexts/env.context";
+import { useUIContext } from "src/contexts/ui.context";
+import { useFaucetStyles } from "src/views/faucet/faucet.styles";
+import { Button } from "src/views/shared/button/button.view";
+import { Typography } from "src/views/shared/typography/typography.view";
+
+type RequestStatus = "error" | "idle" | "loading" | "success";
+
+const isValidAddress = (value: string): boolean => /^0x[a-fA-F0-9]{40}$/.test(value.trim());
+
+const readEnv = (key: string): string | undefined => {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+  const value = import.meta.env[key];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+};
+
+export const FaucetRedesign: FC = () => {
+  const classes = useFaucetStyles();
+  const env = useEnvContext();
+  const { openSnackbar } = useUIContext();
+  const [address, setAddress] = useState("");
+  const [status, setStatus] = useState<RequestStatus>("idle");
+
+  if (!env) {
+    return null;
+  }
+
+  const LogoMark = brand.assets.LogoMark;
+  const tokenSymbol = brand.faucet.tokenSymbol;
+  const networkName = env.networkName ?? "Devnet";
+  const logoPath = env.logoPath;
+  const apiUrl = readEnv("VITE_FAUCET_API_URL") ?? brand.faucet.apiUrl;
+  const servingFrom = readEnv("VITE_FAUCET_SERVING_ADDRESS");
+  const supportUrl = brand.faucet.supportUrl;
+
+  const canRequest = apiUrl.length > 0 && isValidAddress(address) && status !== "loading";
+
+  const onCopyServingAddress = () => {
+    if (servingFrom) {
+      copy(servingFrom);
+      openSnackbar({ text: "Address copied to clipboard", type: "success-msg" });
+    }
+  };
+
+  const onRequest = () => {
+    if (!canRequest) {
+      return;
+    }
+    setStatus("loading");
+    requestFaucetFunds({ address: address.trim(), apiUrl })
+      .then(() => {
+        setStatus("success");
+        openSnackbar({ text: `${tokenSymbol} request submitted.`, type: "success-msg" });
+      })
+      .catch(() => {
+        setStatus("error");
+      });
+  };
+
+  return (
+    <div className={classes.faucet}>
+      <div className={classes.contentWrapper}>
+        <span className={classes.badge}>
+          <span className={classes.badgeDot} /> {networkName}
+        </span>
+        {logoPath ? (
+          <img alt={networkName} className={classes.mark} src={logoPath} />
+        ) : (
+          <LogoMark className={classes.mark} />
+        )}
+        <Typography className={classes.heading} type="h1">
+          <span className={classes.headingAccent}>Receive</span> 1 {tokenSymbol}
+        </Typography>
+
+        <div className={classes.card}>
+          {servingFrom && (
+            <div className={classes.servingRow}>
+              <span className={classes.fieldLabel}>Serving from</span>
+              <span className={classes.servingValue}>
+                <span className={classes.servingAddress}>{servingFrom}</span>
+                <button
+                  aria-label="Copy serving address"
+                  className={classes.copyButton}
+                  onClick={onCopyServingAddress}
+                >
+                  <CopyIcon className={classes.copyIcon} />
+                </button>
+              </span>
+            </div>
+          )}
+
+          <input
+            className={classes.addressInput}
+            onChange={(event) => {
+              setAddress(event.target.value);
+              if (status !== "idle") {
+                setStatus("idle");
+              }
+            }}
+            placeholder="Enter your address"
+            spellCheck={false}
+            value={address}
+          />
+
+          <div className={classes.buttonWrap}>
+            <Button
+              disabled={!canRequest}
+              isLoading={status === "loading"}
+              onClick={onRequest}
+            >
+              Request
+            </Button>
+          </div>
+
+          {status === "success" && (
+            <p className={classes.requestSuccess}>
+              Request submitted. Test tokens will arrive shortly.
+            </p>
+          )}
+          {status === "error" && (
+            <p className={classes.requestError}>Request failed. Please try again.</p>
+          )}
+
+          <p className={classes.helperText}>
+            Claim 1 {tokenSymbol} test token for development.
+            <br />
+            {supportUrl ? (
+              <>
+                If you need additional tokens for extensive testing, please{" "}
+                <a
+                  className={classes.helperLink}
+                  href={supportUrl}
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  contact support
+                </a>
+                .
+              </>
+            ) : (
+              "If you need additional tokens for extensive testing, please contact support."
+            )}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/views/shared/header-links/header-links.view.redesign.tsx
+++ b/src/views/shared/header-links/header-links.view.redesign.tsx
@@ -2,9 +2,11 @@ import { useEffect, useRef, useState } from "react";
 import { useHeaderLinksRedesignStyles } from "./header-links.styles";
 import ArrowRight  from "src/assets/icons/arrow-right-white.svg?react";
 import BurgerMenuIcon  from "src/assets/icons/burger-menu.svg?react";
-import LogoGatewayfm  from "src/assets/icons/logo-gatewayfm.svg?react";
+import { brand } from "src/brands";
 
 type LinkItem = { title: string; url: string };
+
+const Logo = brand.assets.Logo;
 
 export const HeaderLinks = () => {
   const [openBurgerMenu, setOpenBurgerMenu] = useState(false);
@@ -12,23 +14,21 @@ export const HeaderLinks = () => {
   const burgerIconRef = useRef<HTMLDivElement>(null);
   const classes = useHeaderLinksRedesignStyles();
   const isMobile = window.innerWidth < 788;
+  const { deployButton } = brand.header;
 
   const linksList: LinkItem[] = [
-    { title: "Rollup", url: "https://gateway.fm/presto" },
-    { title: "Stakeway", url: "https://stakeway.com/" },
-    { title: "RPC", url: "https://gateway.fm/rpc" },
-    { title: "Blog", url: "https://gateway.fm/blog" },
-    { title: "About", url: "https://gateway.fm/about" },
-    { title: "Careers", url: "https://boards.eu.greenhouse.io/gatewayfm" },
-    ...(isMobile ? [{ title: "Deploy rollup", url: "https://presto.gateway.fm/onboarding" }] : []),
+    ...brand.header.links,
+    ...(isMobile && deployButton ? [deployButton] : []),
   ];
 
   const onOpenBurgerMenu = () => {
     setOpenBurgerMenu((prev) => !prev);
   };
 
-  const redirectToPrestoOnboarding = () => {
-    window.open("https://presto.gateway.fm/onboarding", "_blank");
+  const redirectToDeploy = () => {
+    if (deployButton) {
+      window.open(deployButton.url, "_blank");
+    }
   };
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
@@ -61,9 +61,9 @@ export const HeaderLinks = () => {
   return (
     <div className={classes.wrapper}>
       <div className={classes.linksAndLogoContainer}>
-        <LogoGatewayfm
+        <Logo
           className={classes.logo}
-          onClick={() => window.open("https://gateway.fm/", "_blank")}
+          onClick={() => window.open(brand.header.homeUrl, "_blank")}
         />
         <div ref={burgerIconRef}>
           <BurgerMenuIcon
@@ -90,9 +90,11 @@ export const HeaderLinks = () => {
           ))}
         </div>
       </div>
-      <button className={classes.button} onClick={redirectToPrestoOnboarding}>
-        Deploy rollup <ArrowRight className={classes.icon} />
-      </button>
+      {deployButton && (
+        <button className={classes.button} onClick={redirectToDeploy}>
+          {deployButton.title} <ArrowRight className={classes.icon} />
+        </button>
+      )}
     </div>
   );
 };

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -26,6 +26,19 @@ export default defineConfig({
   },
   server: {
     open: true,
+    // Dev-only, opt-in reverse proxy so a same-origin faucet/API can be hit from
+    // localhost without CORS. Set FAUCET_PROXY_TARGET when running `npm run dev`
+    // and point VITE_FAUCET_API_URL at `/faucet-api/api/claim`. No effect on build.
+    proxy: process.env.FAUCET_PROXY_TARGET
+      ? {
+          "/faucet-api": {
+            changeOrigin: true,
+            rewrite: (requestPath) => requestPath.replace(/^\/faucet-api/, ""),
+            secure: true,
+            target: process.env.FAUCET_PROXY_TARGET,
+          },
+        }
+      : undefined,
     watch: {
       ignored: ["!**/*.tsx", "!**/*.ts", "**/*.json", "**/*.svg?react", "**/*.png", "**/*.jpg", "**/*.css"],
     },


### PR DESCRIPTION
> **Draft — sharing progress, not ready to merge.** PRST-4126 is `Blocked` pending the
> client's decision on the custom design. Opening this so the team can review the
> white-label architecture, which is useful independently of the TEIZA deal.

## What this does

Adds a **build-time brand layer** so client-specific designs live in one shared tree
instead of per-client forks — dependency and security bumps land once on `develop` and
every brand picks them up on its next build. Then applies it to the "Gateway Makeover x
TEIZA" design and adds the faucet screen from that deck.

Brand selection is **orthogonal** to `VITE_FRONTEND_TYPE` (`old-design` / `new-design`),
which is untouched. A brand skins whichever layout is active.

## Changes

**`src/brands/`** — a `Brand` type + registry resolved from `VITE_BRAND` at build time.

- `base` reproduces the previously hard-coded Gateway palette, font faces and header
  links. Unset or unknown `VITE_BRAND` falls back to it.
- `teiza` — blue palette, logo/mark/network-mark SVGs, Poppins-led font stack,
  marketing header links, faucet config.

**Consumption points** — `theme.ts` and `app.styles.ts` source palette, font family and
`@font-face` from the active brand (existing `VITE_THEME_COLOR_*` env overrides still
win); `header-links` and the layout "Powered by" footer consume brand logo assets and URLs.

**New `/faucet` screen** (`src/views/faucet/`) — the deck's "Receive 1 TTT" page: network
badge, mark, two-tone heading, serving-from address + copy, address input with validation,
Request button, helper text. Wired to an `eth-faucet` style `POST {address}` endpoint via
`src/adapters/faucet-api.ts`. The route is **only registered when the active brand enables
the faucet**, so `base` builds are unaffected.

**Deployability** — `scripts/deploy.sh` passes the brand + faucet vars through,
`.env.example` documents them, and `docs/branding/teiza.md` is the handoff doc plus an
onboarding guide for adding the next client brand.

**`vite.config.ts`** — opt-in **dev-only** reverse proxy (`FAUCET_PROXY_TARGET`) so a
faucet on another origin can be exercised from localhost without CORS. No effect on builds.

## Verification

- `tsc --noEmit` — 0 errors.
- `eslint ./src/**/*.{ts,tsx}` — 0 errors/warnings.
- Production build passes for **both** `VITE_BRAND=base` and `VITE_BRAND=teiza`; confirmed
  in the emitted bundle that the brand actually resolves in each case (not silently
  falling back).
- Ran locally against real teiza-devnet params; faucet endpoint confirmed reachable
  through the dev proxy.

One accuracy note on the handoff doc: it claims a no-`VITE_BRAND` build is "byte-identical
to before". The registry statically imports every brand, so the TEIZA tokens are present in
a `base` bundle and it is marginally larger. Behaviour is identical; the wording isn't.
Worth a lazy/dynamic registry if we care, but that trades away the build-time resolution.

## Not included

The client design deck PDF and a stray `.env.billions.bak` are deliberately left out of
the commit — this repo is public.

## Pending client confirmation (for pixel-exactness)

1. Real typeface (name + font files) — currently Poppins with Modern Era fallback.
2. Exact hex values — currently eyeballed from the PDF (primary `#2C48F6`).
3. Official logo/mark/network SVGs — currently hand-recreated from the deck.
4. Header link + support URLs — currently `teiza.io/*` placeholders.
5. Faucet API contract, and whether the faucet is exposed under the bridge origin.

## Enabling in prod (when unblocked)

Add `VITE_BRAND=teiza` to
`prod-gateway-eks-cluster/rollups/cdk-erigon-testnet-teiza-devnet/bridge/ui/config/ui.env`
(it already sets `VITE_FRONTEND_TYPE=new-design` and `VITE_BRAND_COMPONENTS=true`),
optionally `VITE_FAUCET_API_URL` / `VITE_FAUCET_SERVING_ADDRESS`, then bump the image tag.

Linear: [PRST-4126](https://linear.app/gateway-fm/issue/PRST-4126/apply-teiza-branding-faucet-to-bridge-ui-white-label-brand)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
