### PR TITLE
ci: manual build-teiza workflow (dispatch handle for custom/teiza)

### DIFF
--- a/.github/workflows/build-teiza.yml
+++ b/.github/workflows/build-teiza.yml
@@ -1,0 +1,44 @@
+name: build-teiza
+
+# Manual build of the TEIZA co-branded bridge UI from the long-lived
+# custom/teiza branch. The image tag is immutable: pick a new version for
+# every build (suggested scheme: <generic version this branch is rebased
+# on>-teiza.<n>, e.g. teiza-1.1.24).
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version suffix; the image is tagged zkevm-bridge-ui-generic:teiza-<version>"
+        required: true
+        type: string
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout custom/teiza
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: custom/teiza
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      - name: Login to DockerHub
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push the TEIZA image
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        with:
+          platforms: linux/amd64,linux/arm64
+          push: true
+          pull: true
+          tags: |
+            gatewayfm/zkevm-bridge-ui-generic:teiza-${{ inputs.version }}


### PR DESCRIPTION
Adds a `workflow_dispatch`-only workflow that builds the co-branded bridge UI **from the long-lived `custom/teiza` branch** (explicit checkout ref) and pushes `gatewayfm/zkevm-bridge-ui-generic:teiza-<version>` (multi-arch, immutable version tag chosen at dispatch time).

Why it lands on `develop`: GitHub only offers manual triggers for workflows present on the default branch. This workflow never builds `develop` itself — it is only the dispatch handle; the built source always comes from `custom/teiza`.

The customization branch model: `custom/teiza` lives permanently beside `develop` (never merged), rebased onto it periodically so dependency/security bumps reach the custom build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)