### PR TITLE
ci: explicit minimal GITHUB_TOKEN permissions for build-teiza

### DIFF
--- a/.github/workflows/build-teiza.yml
+++ b/.github/workflows/build-teiza.yml
@@ -13,6 +13,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Follow-up to #91: adds the explicit `permissions: contents: read` block flagged by CodeQL (workflow did not limit the GITHUB_TOKEN). No functional change — Docker Hub auth uses repo secrets, the job never writes to the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)